### PR TITLE
fix connection string env var keys

### DIFF
--- a/RGO.Utility/RGO_DatasetExporter.cs
+++ b/RGO.Utility/RGO_DatasetExporter.cs
@@ -26,7 +26,7 @@ public class RGO_DatasetExporter
     public string GenerateExportableData()
     {
         var _config = new ConfigurationBuilder().AddJsonFile("appsettings.json").Build();
-        var ConnectionString = System.Environment.GetEnvironmentVariable("ConnectionStrings:DefaultConnection") ?? _config.GetValue(typeof(object), "ConnectionStrings:DefaultConnection");
+        var ConnectionString = System.Environment.GetEnvironmentVariable("ConnectionStrings__DefaultConnection") ?? _config.GetValue(typeof(object), "ConnectionStrings:DefaultConnection");
         var server = new DiscoveredServer(ConnectionString.ToString(), DatabaseType.PostgreSql);
         using var conn = server.GetConnection();
         conn.Open();

--- a/RGO/CSV_Uploader.cs
+++ b/RGO/CSV_Uploader.cs
@@ -357,7 +357,7 @@ group by rec.""RGO_RecordId"") as mid on mid.""RGO_RecordId"" = rec.""RGO_Record
             from rc
             group by ""RGO_RecordId""
             ";
-        var ConnectionString = System.Environment.GetEnvironmentVariable("ConnectionStrings:DefaultConnection")?? _config.GetValue(typeof(object), "ConnectionStrings:DefaultConnection");
+        var ConnectionString = System.Environment.GetEnvironmentVariable("ConnectionStrings__DefaultConnection")?? _config.GetValue(typeof(object), "ConnectionStrings:DefaultConnection");
         var server = new DiscoveredServer(ConnectionString.ToString(), DatabaseType.PostgreSql);
         using var conn = server.GetConnection();
         conn.Open();
@@ -407,7 +407,7 @@ group by rec.RGO_RecordId) as mid on mid.RGO_RecordId = rec.RGO_RecordId
                 for Name in ( {columns})
             ) p
             ";
-        var ConnectionString = System.Environment.GetEnvironmentVariable("ConnectionStrings:DefaultConnection") ?? _config.GetValue(typeof(object), "ConnectionStrings:DefaultConnection");
+        var ConnectionString = System.Environment.GetEnvironmentVariable("ConnectionStrings__DefaultConnection") ?? _config.GetValue(typeof(object), "ConnectionStrings:DefaultConnection");
         var server = new DiscoveredServer(ConnectionString.ToString(), DatabaseType.MicrosoftSQLServer);
         using var conn = server.GetConnection();
         conn.Open();


### PR DESCRIPTION
See https://learn.microsoft.com/en-us/dotnet/core/extensions/configuration-providers#environment-variable-configuration-provider for setting env vars on Linux where `:` is prohibited.